### PR TITLE
Set up email configuration for portfolio

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -16,6 +16,13 @@ const nextConfig = {
 		// optimizeCss: true, // Commented out to avoid critters dependency
 		optimizePackageImports: ['lucide-react', 'framer-motion'],
 	},
+	// Explicitly expose environment variables for standalone mode
+	env: {
+		NODE_MAILER_HOST: process.env.NODE_MAILER_HOST,
+		NODE_MAILER_PORT: process.env.NODE_MAILER_PORT,
+		NODE_MAILER_USER: process.env.NODE_MAILER_USER,
+		NODE_MAILER_PASS: process.env.NODE_MAILER_PASS,
+	},
 };
 
 export default nextConfig;


### PR DESCRIPTION
Configure next.config.mjs to explicitly expose email service environment variables for Next.js standalone builds. This ensures the nodemailer configuration is available at runtime in Docker deployments.