### PR TITLE
Debug and fix console errors

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -23,6 +23,33 @@ const nextConfig = {
 		NODE_MAILER_USER: process.env.NODE_MAILER_USER,
 		NODE_MAILER_PASS: process.env.NODE_MAILER_PASS,
 	},
+	// Configure headers for security and analytics
+	async headers() {
+		return [
+			{
+				source: '/:path*',
+				headers: [
+					{
+						key: 'Content-Security-Policy',
+						value: [
+							"default-src 'self'",
+							"script-src 'self' 'unsafe-eval' 'unsafe-inline' https://www.googletagmanager.com https://*.google-analytics.com",
+							"style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+							"img-src 'self' data: https: blob:",
+							"font-src 'self' data: https://fonts.gstatic.com",
+							"connect-src 'self' https://*.google-analytics.com https://www.google-analytics.com https://analytics.google.com https://region1.google-analytics.com https://*.analytics.google.com",
+							"frame-src 'self' https://www.googletagmanager.com",
+							"object-src 'none'",
+							"base-uri 'self'",
+							"form-action 'self'",
+							"frame-ancestors 'none'",
+							"upgrade-insecure-requests"
+						].join('; ')
+					},
+				],
+			},
+		];
+	},
 };
 
 export default nextConfig;


### PR DESCRIPTION
…omains

Added CSP headers configuration in next.config.mjs to resolve console errors related to Google Analytics being blocked. The CSP now allows:
- Regional Google Analytics domains (*.google-analytics.com)
- All necessary analytics endpoints for proper tracking
- Required scripts, styles, and fonts for the application

This fixes the CSP violations that were preventing Google Analytics from loading properly.